### PR TITLE
Widening-based map() to remove return_type

### DIFF
--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -1,8 +1,32 @@
 function Base.map(f, a::StaticArrayLite)
-    T = Core.Compiler.return_type(f, Tuple{eltype(a)})
-    out = similar(a, T, size(a))
-    map!(f, out, a)
-    return freeze(out)
+    if length(a) == 0
+        T = Core.Compiler.return_type(f, Tuple{eltype(a)})
+        return freeze(similar(a, T, size(a)))
+    end
+    @inbounds x = f(a[first(LinearIndices(a))])
+    out = similar(a, typeof(x), size(a))
+    freeze(_map_widen!(out, 0, x, f, a))
+end
+
+function _map_widen!(out, offset, x, f, a)
+    a_i1 = first(LinearIndices(a))
+    out_i1 = first(LinearIndices(out))
+    T = eltype(out)
+    while true
+        @inbounds out[out_i1+offset] = x
+        offset += 1
+        if offset >= length(a)
+            break
+        end
+        @inbounds x = f(a[a_i1+offset])
+        if !(typeof(x) === T || x isa T)
+            T2 = Base.promote_typejoin(T, typeof(x))
+            out2 = similar(a, T2, size(a))
+            copyto!(out2, out_i1, out, out_i1, offset)
+            return _map_widen!(out2, )
+        end
+    end
+    return out
 end
 
 function Base.map(f, a::StaticArrayLite, b::StaticArrayLite)


### PR DESCRIPTION
You earn two points https://xkcd.com/356/

It's insane that the compiler removes all the ugly crap I've put in here.
```
julia> v = SArrayLite{Tuple{3}, Float64, 1, 3}((1,2,3))
3-element SArrayLite{Tuple{3},Float64,1,3}:
 1.0
 2.0
 3.0

julia> @code_native map(x->x^2, v)
	.text
; ┌ @ mapreduce.jl:2 within `map'
	movq	%rdi, %rax
; │ @ mapreduce.jl:6 within `map'
; │┌ @ REPL[11]:1 within `#15'
; ││┌ @ intfuncs.jl:261 within `literal_pow'
; │││┌ @ float.jl:405 within `*'
	vmovupd	(%rsi), %xmm0
	vmulpd	%xmm0, %xmm0, %xmm0
; │└└└
; │ @ mapreduce.jl:8 within `map'
; │┌ @ mapreduce.jl:21 within `_map_widen!'
; ││┌ @ REPL[11]:1 within `#15'
; │││┌ @ intfuncs.jl:261 within `literal_pow'
; ││││┌ @ float.jl:405 within `*'
	vmovsd	16(%rsi), %xmm1         # xmm1 = mem[0],zero
	vmulsd	%xmm1, %xmm1, %xmm1
; │└└└└
	vmovupd	%xmm0, (%rdi)
	vmovsd	%xmm1, 16(%rdi)
	retq
	nop
; └
```